### PR TITLE
Fix token init error

### DIFF
--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -509,7 +509,7 @@ ctx.postMessage({
 });
 
 const handleCogniteMessage = async (msg: InMessage) => {
-  // handle Cognite data
+  // Fusion sends in a token to the worker, which we need to set in the environment
   if (msg.type === "newToken") {
     const token = msg.data.token;
     const project = msg.data.project;


### PR DESCRIPTION
Sometimes, Pyodide might start before we have passed the token into the environment. This PR fixes so initialization is not done until we have a token.