### PR TITLE
Parsing message before waiting for ready signal

### DIFF
--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -336,9 +336,9 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
     return;
   }
 
-  await pyodideReadyPromise;
-
   handleCogniteMessage(msg);
+
+  await pyodideReadyPromise;
 
   const messagePort = event.ports[0];
 


### PR DESCRIPTION
The two functions are currently waiting on each other, so that did not work. It's a race condition so it doesn't always happen, but now it should always work.