### PR TITLE
Set Fusion URL if it is passed in

### DIFF
--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -393,17 +393,21 @@ const sendTokenToWorker = (
     token,
     baseUrl,
     project,
+    organization,
+    fusionUrl,
     email,
   }: {
     token: string;
     baseUrl: string;
     project: string;
+    organization: string;
+    fusionUrl: string;
     email?: string;
   },
   worker: StliteWorker
 ) => {
   worker.postMessage({
     type: "newToken",
-    data: { token, baseUrl, project, email },
+    data: { token, baseUrl, organization, fusionUrl, project, email },
   });
 };

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -115,6 +115,8 @@ export interface InTokenMessage extends InMessageBase {
   data: {
     token: string;
     baseUrl: string;
+    fusionUrl: string;
+    organization: string;
     project: string;
     email?: string;
   };

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -528,6 +528,8 @@ const handleCogniteMessage = async (msg: InMessage) => {
     const token = msg.data.token;
     const project = msg.data.project;
     const baseUrl = msg.data.baseUrl;
+    const fusionUrl = msg.data.fusionUrl;
+    const organization = msg.data.organization;
 
     if (token && project && baseUrl) {
       while (!pyodide) {
@@ -540,9 +542,12 @@ const handleCogniteMessage = async (msg: InMessage) => {
         os.environ["COGNITE_TOKEN"] = "${token}"
         os.environ["COGNITE_PROJECT"] = "${project}"
         os.environ["COGNITE_BASE_URL"] = "${baseUrl}"
+        os.environ["COGNITE_FUSION_URL"] = "${fusionUrl}"
+        os.environ["COGNITE_ORGANIZATION"] = "${organization}"
         # Set flag to tell the SDK that we are inside of a Fusion Notebook:
         os.environ["COGNITE_FUSION_NOTEBOOK"] = "1"
       `);
+
       tokenIsSet = true;
     }
   }


### PR DESCRIPTION
Passing in the Fusion URL and organization so they can be set as environment variables in Streamlit.

Partner PR: https://github.com/cognitedata/fusion/pull/4910

https://cognitedata.slack.com/archives/C055DQNSM6E/p1706472099453569?thread_ts=1706217329.643659&cid=C055DQNSM6E

This enables
![image](https://github.com/cognitedata/stlite/assets/16174/25cefe41-8782-4bbc-a7bf-87b3991d0943)
