### PR TITLE
feat: Hover support for StreamLit

### DIFF
--- a/packages/kernel/src/cognite/language-server-types.ts
+++ b/packages/kernel/src/cognite/language-server-types.ts
@@ -17,5 +17,11 @@ export interface OutMessageLangugeServerAutocomplete {
 }
 export interface OutMessageLangugeServerHover {
   type: LanguageServerEvents.hover;
-  data: string;
+  /**
+   * Decided to use unknown to avoid importing whole package and bunch of stuff
+   * https://microsoft.github.io/monaco-editor/typedoc/interfaces/languages.Hover.html
+   */
+  data: {
+    contents: { value: string };
+  };
 }

--- a/packages/kernel/src/cognite/language-server-types.ts
+++ b/packages/kernel/src/cognite/language-server-types.ts
@@ -1,5 +1,6 @@
 export enum LanguageServerEvents {
   autocomplete = "language-server:autocomplete",
+  hover = "language-server:hover",
 }
 
 export interface OutMessageLangugeServerAutocomplete {
@@ -13,4 +14,8 @@ export interface OutMessageLangugeServerAutocomplete {
      */
     items: unknown[];
   };
+}
+export interface OutMessageLangugeServerHover {
+  type: LanguageServerEvents.hover;
+  data: string;
 }

--- a/packages/kernel/src/cognite/language-server-utils.test.ts
+++ b/packages/kernel/src/cognite/language-server-utils.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+
+import { loadPyodide, PyodideInterface } from "pyodide";
+import { describe, expect, it, vi } from "vitest";
+import {
+  get_hover,
+  importLanguageServerPythonLibraries,
+} from "./language-server-utils";
+
+const JEDI_WHEEL = new URL(
+  "../../py/jedi/jedi-0.19.1-py2.py3-none-any.whl",
+  import.meta.url
+).href;
+
+vi.mock("./cognite/streamlit-worker-communication-utils", () => {
+  return {
+    postMessageToStreamLitWorker: vi.fn(),
+  };
+});
+
+describe("LanguageServerUtils test", () => {
+  let pyodide: PyodideInterface;
+
+  /**
+   * Import only the necesarry dependencies so we can run jedi
+   * and test the language server
+   */
+  beforeAll(async () => {
+    const jediWheelUrl = JEDI_WHEEL as unknown as string;
+    const wheels = {
+      jedi: jediWheelUrl,
+    };
+
+    pyodide = await loadPyodide({
+      indexURL: "../../node_modules/pyodide", // Installed at the Yarn workspace root
+      stdout: console.log,
+      stderr: console.error,
+    });
+
+    await pyodide.loadPackage("micropip");
+    const micropip = pyodide.pyimport("micropip");
+    console.log("Installing the wheels:", wheels);
+
+    await micropip.install.callKwargs([wheels.jedi], { keep_going: true });
+
+    // The following code is necessary to avoid errors like  `NameError: name '_imp' is not defined`
+    // at importing installed packages.
+    await pyodide.runPythonAsync(`
+    import importlib
+    importlib.invalidate_caches()
+    `);
+
+    console.log("Importing Language Server");
+    await importLanguageServerPythonLibraries(pyodide, micropip);
+  });
+
+  describe("Test Hover", () => {
+    it("should provide hover information for modules and properties", async () => {
+      const code = `import math
+math.cos()
+`;
+      const hover = await get_hover(
+        {
+          data: {
+            code: code,
+            currentLine: "math",
+            currentLineNumber: 2,
+            offset: 5,
+          },
+          type: "language-server:hover",
+        },
+        pyodide
+      );
+
+      expect(hover).toEqual(
+        expect.objectContaining({
+          contents: {
+            kind: "markdown",
+            value:
+              "```python\ncos(x: SupportsFloat, /) -> float\n```\n\n```\nReturn the cosine of x (measured in radians).\n```",
+          },
+        })
+      );
+    });
+
+    it("should handle invalid requests and return empty response", async () => {
+      const code = `import math
+      math.cos()
+      `;
+      const hover = await get_hover(
+        {
+          data: {
+            code: code,
+            currentLine: "math",
+            currentLineNumber: 3,
+            offset: 5,
+          },
+          type: "language-server:hover",
+        },
+        pyodide
+      );
+
+      expect(hover).toEqual(
+        expect.objectContaining({
+          contents: {
+            kind: "markdown",
+            value: "",
+          },
+        })
+      );
+    });
+  });
+});

--- a/packages/kernel/src/cognite/language-server-utils.test.ts
+++ b/packages/kernel/src/cognite/language-server-utils.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { loadPyodide, PyodideInterface } from "pyodide";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeAll } from "vitest";
 import {
   get_hover,
   get_code_completions,

--- a/packages/kernel/src/cognite/language-server-utils.ts
+++ b/packages/kernel/src/cognite/language-server-utils.ts
@@ -2,7 +2,7 @@ import { InMessageAutocomplete, InMessageHover } from "../types";
 import type Pyodide from "pyodide";
 import {
   LanguageServerEvents,
-  OutMessageLangugeServerHover,
+  OutMessageLangugeServerAutocomplete,
 } from "./language-server-types";
 import { postMessageToStreamLitWorker } from "./streamlit-worker-communication-utils";
 import type { StliteWorkerContext } from "../worker";
@@ -177,7 +177,7 @@ export const handleAutoComplete = async (
     data: {
       items: [],
     },
-  };
+  } as OutMessageLangugeServerAutocomplete;
 
   try {
     autoCompleteResponse.data = await get_code_completions(msg, pyodide);

--- a/packages/kernel/src/cognite/language-server-utils.ts
+++ b/packages/kernel/src/cognite/language-server-utils.ts
@@ -1,6 +1,9 @@
-import { InMessageAutocomplete } from "../types";
+import { InMessageAutocomplete, InMessageHover } from "../types";
 import type Pyodide from "pyodide";
-import { LanguageServerEvents } from "./language-server-types";
+import {
+  LanguageServerEvents,
+  OutMessageLangugeServerHover,
+} from "./language-server-types";
 import { postMessageToStreamLitWorker } from "./streamlit-worker-communication-utils";
 import type { StliteWorkerContext } from "../worker";
 
@@ -164,6 +167,107 @@ autocomplete()`
     postMessageToStreamLitWorker(ctx, {
       type: LanguageServerEvents.autocomplete,
       data: suggestions,
+    });
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+export const get_hover = async (
+  msg: InMessageHover,
+  pyodide: Pyodide.PyodideInterface
+) => {
+  try {
+    // Indentation is very important in python, don't change this!
+    const result = await pyodide.runPythonAsync(`import jedi;
+import re;
+import json;
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+from lsprotocol import converters, types
+from jedi.api.classes import Completion, Name  # type: ignore
+from inspect import Parameter
+
+def _docstring_markdown(name: Name) -> str:
+  doc = name.docstring()
+  if not doc:
+    return ''
+  if name.type in ['class', 'function']:
+    try:
+      sig, doc = doc.split("\\n\\n", 1)
+    except ValueError:
+      sig = doc
+      doc = False
+    sig = f"\`\`\`python\\n{sig}\\n\`\`\`"
+    if doc:
+      return f"{sig}\\n\\n\`\`\`\\n{doc}\\n\`\`\`"
+    return sig
+  return f"\`\`\`\\n{doc}\\n\`\`\`"
+
+def hover():
+
+  code = '''
+${msg.data.code}
+  '''
+    
+  script = jedi.Script(code)
+  cursor_line = ${msg.data.currentLineNumber}
+  cursor_character = ${msg.data.offset}
+  jediHoverFunction = script.help
+  hoverFunction = _docstring_markdown
+
+  names = script.help(cursor_line + 1, cursor_character)
+
+  result = '\\n\\n'.join(map(hoverFunction, names))
+
+  if result:
+    hover_result = types.Hover(
+      contents=types.MarkupContent(kind=types.MarkupKind.Markdown, value=result)
+    )
+    converter = converters.get_converter()
+    return json.dumps(converter.unstructure(hover_result, unstructure_as=types.Hover))
+
+  return None
+
+hover()`);
+
+    if (!result) {
+      return {
+        contents: {
+          kind: "markdown",
+          value: "",
+        },
+      };
+    }
+
+    const hover = JSON.parse(result);
+
+    return hover;
+  } catch (err) {
+    console.error(err);
+    return {
+      contents: {
+        kind: "markdown",
+        value: "",
+      },
+    };
+  }
+};
+
+export const handleHover = async (
+  msg: InMessageHover,
+  pyodide: Pyodide.PyodideInterface,
+  ctx: StliteWorkerContext
+) => {
+  try {
+    const hover = await get_hover(msg, pyodide);
+    /**
+     * This is happening inside a function in a web worker
+     * we need to notify the worker that we processed the request
+     * so that the Kernel can send the message to fusion
+     */
+    postMessageToStreamLitWorker(ctx, {
+      type: LanguageServerEvents.hover,
+      data: hover,
     });
   } catch (err) {
     console.error(err);

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -351,6 +351,7 @@ export class StliteKernel {
         this.handleWebSocketMessage && this.handleWebSocketMessage(payload);
         break;
       }
+      case "language-server:hover":
       case "language-server:autocomplete": {
         postMessageToFusion(msg);
         break;
@@ -398,7 +399,7 @@ const initTokenStorageAndAuthHandler = (worker: StliteWorker) => {
         typeof event.data === "object" &&
         "type" in event.data &&
         "data" in event.data &&
-        event.data.type === "language-server:autocomplete"
+        event.data.type.startsWith("language-server:")
       ) {
         worker.postMessage(event.data);
       }

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -126,23 +126,20 @@ export interface InTokenMessage extends InMessageBase {
     email?: string;
   };
 }
+
+interface LanguageServerRequestPayload {
+  code: string;
+  currentLine: string;
+  currentLineNumber: number;
+  offset: number;
+}
 export interface InMessageAutocomplete extends InMessageBase {
   type: "language-server:autocomplete";
-  data: {
-    code: string;
-    currentLine: string;
-    currentLineNumber: number;
-    offset: number;
-  };
+  data: LanguageServerRequestPayload;
 }
 export interface InMessageHover extends InMessageBase {
   type: "language-server:hover";
-  data: {
-    code: string;
-    currentLine: string;
-    currentLineNumber: number;
-    offset: number;
-  };
+  data: LanguageServerRequestPayload;
 }
 
 export type InMessage =

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -1,5 +1,8 @@
 import type { PyodideInterface } from "pyodide";
-import { OutMessageLangugeServerAutocomplete } from "./cognite/language-server-types";
+import {
+  OutMessageLangugeServerAutocomplete,
+  OutMessageLangugeServerHover,
+} from "./cognite/language-server-types";
 
 export type PyodideConvertiblePrimitive =
   | string
@@ -132,6 +135,15 @@ export interface InMessageAutocomplete extends InMessageBase {
     offset: number;
   };
 }
+export interface InMessageHover extends InMessageBase {
+  type: "language-server:hover";
+  data: {
+    code: string;
+    currentLine: string;
+    currentLineNumber: number;
+    offset: number;
+  };
+}
 
 export type InMessage =
   | InMessageInitData
@@ -143,7 +155,8 @@ export type InMessage =
   | InMessageFileUnlink
   | InMessageInstall
   | InTokenMessage
-  | InMessageAutocomplete;
+  | InMessageAutocomplete
+  | InMessageHover;
 
 export interface StliteWorker extends Worker {
   postMessage(message: InMessage, transfer: Transferable[]): void;
@@ -187,7 +200,8 @@ export type OutMessage =
   | OutMessageErrorEvent
   | OutMessageLoadedEvent
   | OutMessageWebSocketBack
-  | OutMessageLangugeServerAutocomplete;
+  | OutMessageLangugeServerAutocomplete
+  | OutMessageLangugeServerHover;
 
 /**
  * Reply message to InMessage

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -12,6 +12,7 @@ import type {
 import { LanguageServerEvents } from "./cognite/language-server-types";
 import {
   get_code_completions,
+  handleHover,
   importLanguageServerPythonLibraries,
 } from "./cognite/language-server-utils";
 
@@ -560,5 +561,7 @@ const handleCogniteMessage = async (msg: InMessage) => {
     }
   } else if (tokenIsSet && msg.type === LanguageServerEvents.autocomplete) {
     get_code_completions(msg, pyodide, ctx);
+  } else if (tokenIsSet && msg.type === LanguageServerEvents.hover) {
+    handleHover(msg, pyodide, ctx);
   }
 };

--- a/packages/kernel/vitest.config.ts
+++ b/packages/kernel/vitest.config.ts
@@ -4,7 +4,9 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   test: {
+    globals: true, // allows us to use vitest library methods in unit test without explicit imports
     environment: "jsdom", // We use jsdom because happy-dom does not work well with iframe.
     setupFiles: ["./setupTests.ts"],
   },
+  assetsInclude: ["./py/*"],
 });

--- a/packages/kernel/vitest.config.ts
+++ b/packages/kernel/vitest.config.ts
@@ -4,9 +4,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   test: {
-    globals: true, // allows us to use vitest library methods in unit test without explicit imports
     environment: "jsdom", // We use jsdom because happy-dom does not work well with iframe.
     setupFiles: ["./setupTests.ts"],
   },
-  assetsInclude: ["./py/*"],
 });


### PR DESCRIPTION
Extending the Language Server utils with hover support.
It uses `jedi` to get the information and maps back to VS code or `language-server-protocol` standard.

I added some tests as well.

There is another PR related to this one in the fusion monorepo

**How to test**

* If you want to test it locally, make sure that you run build first for both `kernel` and `mountable`. Ex: Inside kernel, run `npm run build` and do the same of mountable
* After that you can run `mountable` `npm run start`