### PR TITLE
feat: Generate App Screenshot

### DIFF
--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -36,6 +36,7 @@
     "@stlite/common": "^0.54.1",
     "@streamlit/app": "1.33.0",
     "@streamlit/lib": "1.33.0",
+    "html2canvas": "^1.4.1",
     "path-browserify": "^1.0.1"
   }
 }

--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -92,7 +92,6 @@ const Canvas2Image = () => {
 
   /**
    * create bitmap image
-   * 按照规则生成图片响应头和响应体
    */
   const genBitmapImage = function (oData: any) {
     //

--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -2,6 +2,9 @@
 // @ts-ignore
 import html2canvas from "html2canvas";
 
+/**
+ * Copy-paste code from GPT
+ */
 const Canvas2Image = () => {
   // check if support sth.
   const $support = (function () {
@@ -278,7 +281,6 @@ const Canvas2Image = () => {
 export const generateAppScreenshot = async () => {
   try {
     const el = document.querySelector(".stApp") as HTMLDivElement;
-    console.log(el);
     const canvas = await html2canvas(el, {
       allowTaint: true,
       x: 0,
@@ -287,11 +289,7 @@ export const generateAppScreenshot = async () => {
       scrollY: 0,
     });
 
-    console.log("el", el, "canvas", canvas);
-
-    const base64Img = Canvas2Image()!.convertToJPEG(canvas, 258, 150)!.src;
-    console.log("img", base64Img);
-    return base64Img;
+    return Canvas2Image()!.convertToJPEG(canvas, 258, 150)!.src;
   } catch (err) {
     console.error(err);
   }

--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -1,0 +1,298 @@
+/* eslint-disable */
+// @ts-ignore
+import html2canvas from "html2canvas";
+
+const Canvas2Image = () => {
+  // check if support sth.
+  const $support = (function () {
+    const canvas = document.createElement("canvas"),
+      ctx = canvas.getContext("2d")!;
+
+    return {
+      canvas: !!ctx,
+      imageData: !!ctx.getImageData,
+      dataURL: !!canvas.toDataURL,
+      btoa: !!window.btoa,
+    };
+  })();
+
+  function scaleCanvas(
+    canvas: HTMLCanvasElement,
+    width: number,
+    height: number
+  ) {
+    const w = canvas.width,
+      h = canvas.height;
+    if (width === undefined) {
+      width = w;
+    }
+    if (height === undefined) {
+      height = h;
+    }
+
+    let retCanvas = document.createElement("canvas") as HTMLCanvasElement;
+    let retCtx = retCanvas.getContext("2d");
+    retCanvas.width = width;
+    retCanvas.height = height;
+    retCtx!.drawImage(canvas, 0, 0, w, h, 0, 0, width, height);
+    return retCanvas;
+  }
+
+  function getDataURL(
+    canvas: HTMLCanvasElement,
+    type: string,
+    width: number,
+    height: number
+  ) {
+    canvas = scaleCanvas(canvas, width, height);
+    return canvas.toDataURL(type);
+  }
+
+  function genImage(strData: string) {
+    let img = document.createElement("img");
+    img.src = strData;
+    return img;
+  }
+
+  function fixType(type: string) {
+    type = type.toLowerCase().replace(/jpg/i, "jpeg");
+    const r = type.match(/png|jpeg|bmp|gif/)![0];
+    return "image/" + r;
+  }
+
+  function encodeData(data: any) {
+    if (!window.btoa) {
+      // eslint-disable-next-line no-throw-literal
+      throw "btoa undefined";
+    }
+    let str = "";
+    if (typeof data == "string") {
+      str = data;
+    } else {
+      for (let i = 0; i < data.length; i++) {
+        str += String.fromCharCode(data[i]);
+      }
+    }
+
+    return btoa(str);
+  }
+
+  function getImageData(canvas: HTMLCanvasElement) {
+    const w = canvas.width,
+      h = canvas.height;
+    return canvas.getContext("2d")!.getImageData(0, 0, w, h);
+  }
+
+  function makeURI(strData: string, type: string) {
+    return "data:" + type + ";base64," + strData;
+  }
+
+  /**
+   * create bitmap image
+   * 按照规则生成图片响应头和响应体
+   */
+  const genBitmapImage = function (oData: any) {
+    //
+    // BITMAPFILEHEADER: http://msdn.microsoft.com/en-us/library/windows/desktop/dd183374(v=vs.85).aspx
+    // BITMAPINFOHEADER: http://msdn.microsoft.com/en-us/library/dd183376.aspx
+    //
+
+    const biWidth = oData.width;
+    const biHeight = oData.height;
+    const biSizeImage = biWidth * biHeight * 3;
+    const bfSize = biSizeImage + 54; // total header size = 54 bytes
+
+    //
+    //  typedef struct tagBITMAPFILEHEADER {
+    //  	WORD bfType;
+    //  	DWORD bfSize;
+    //  	WORD bfReserved1;
+    //  	WORD bfReserved2;
+    //  	DWORD bfOffBits;
+    //  } BITMAPFILEHEADER;
+    //
+    const BITMAPFILEHEADER = [
+      // WORD bfType -- The file type signature; must be "BM"
+      0x42,
+      0x4d,
+      // DWORD bfSize -- The size, in bytes, of the bitmap file
+      bfSize & 0xff,
+      (bfSize >> 8) & 0xff,
+      (bfSize >> 16) & 0xff,
+      (bfSize >> 24) & 0xff,
+      // WORD bfReserved1 -- Reserved; must be zero
+      0,
+      0,
+      // WORD bfReserved2 -- Reserved; must be zero
+      0,
+      0,
+      // DWORD bfOffBits -- The offset, in bytes, from the beginning of the BITMAPFILEHEADER structure to the bitmap bits.
+      54,
+      0,
+      0,
+      0,
+    ];
+
+    //
+    //  typedef struct tagBITMAPINFOHEADER {
+    //  	DWORD biSize;
+    //  	LONG  biWidth;
+    //  	LONG  biHeight;
+    //  	WORD  biPlanes;
+    //  	WORD  biBitCount;
+    //  	DWORD biCompression;
+    //  	DWORD biSizeImage;
+    //  	LONG  biXPelsPerMeter;
+    //  	LONG  biYPelsPerMeter;
+    //  	DWORD biClrUsed;
+    //  	DWORD biClrImportant;
+    //  } BITMAPINFOHEADER, *PBITMAPINFOHEADER;
+    //
+    const BITMAPINFOHEADER = [
+      // DWORD biSize -- The number of bytes required by the structure
+      40,
+      0,
+      0,
+      0,
+      // LONG biWidth -- The width of the bitmap, in pixels
+      biWidth & 0xff,
+      (biWidth >> 8) & 0xff,
+      (biWidth >> 16) & 0xff,
+      (biWidth >> 24) & 0xff,
+      // LONG biHeight -- The height of the bitmap, in pixels
+      biHeight & 0xff,
+      (biHeight >> 8) & 0xff,
+      (biHeight >> 16) & 0xff,
+      (biHeight >> 24) & 0xff,
+      // WORD biPlanes -- The number of planes for the target device. This value must be set to 1
+      1,
+      0,
+      // WORD biBitCount -- The number of bits-per-pixel, 24 bits-per-pixel -- the bitmap
+      // has a maximum of 2^24 colors (16777216, Truecolor)
+      24,
+      0,
+      // DWORD biCompression -- The type of compression, BI_RGB (code 0) -- uncompressed
+      0,
+      0,
+      0,
+      0,
+      // DWORD biSizeImage -- The size, in bytes, of the image. This may be set to zero for BI_RGB bitmaps
+      biSizeImage & 0xff,
+      (biSizeImage >> 8) & 0xff,
+      (biSizeImage >> 16) & 0xff,
+      (biSizeImage >> 24) & 0xff,
+      // LONG biXPelsPerMeter, unused
+      0,
+      0,
+      0,
+      0,
+      // LONG biYPelsPerMeter, unused
+      0,
+      0,
+      0,
+      0,
+      // DWORD biClrUsed, the number of color indexes of palette, unused
+      0,
+      0,
+      0,
+      0,
+      // DWORD biClrImportant, unused
+      0,
+      0,
+      0,
+      0,
+    ];
+
+    const iPadding = (4 - ((biWidth * 3) % 4)) % 4;
+
+    const aImgData = oData.data;
+
+    let strPixelData = "";
+    const biWidth4 = biWidth << 2;
+    let y = biHeight;
+    const fromCharCode = String.fromCharCode;
+
+    do {
+      const iOffsetY = biWidth4 * (y - 1);
+      let strPixelRow = "";
+      for (let x = 0; x < biWidth; x++) {
+        const iOffsetX = x << 2;
+        strPixelRow +=
+          fromCharCode(aImgData[iOffsetY + iOffsetX + 2]) +
+          fromCharCode(aImgData[iOffsetY + iOffsetX + 1]) +
+          fromCharCode(aImgData[iOffsetY + iOffsetX]);
+      }
+
+      for (let c = 0; c < iPadding; c++) {
+        strPixelRow += String.fromCharCode(0);
+      }
+
+      strPixelData += strPixelRow;
+    } while (--y);
+
+    return (
+      // @ts-ignore
+      encodeData(BITMAPFILEHEADER.concat(BITMAPINFOHEADER)) +
+      encodeData(strPixelData)
+    );
+  };
+
+  const convertToImage = function (
+    canvas: HTMLCanvasElement,
+    width: number,
+    height: number,
+    type: string
+  ) {
+    if ($support.canvas && $support.dataURL) {
+      if (typeof canvas == "string") {
+        canvas = document.getElementById(canvas) as HTMLCanvasElement;
+      }
+      if (type === undefined) {
+        type = "png";
+      }
+      type = fixType(type);
+
+      if (/bmp/.test(type)) {
+        const data = getImageData(scaleCanvas(canvas, width, height));
+        const strData = genBitmapImage(data);
+        return genImage(makeURI(strData, "image/bmp"));
+      } else {
+        const strData = getDataURL(canvas, type, width, height);
+        return genImage(strData);
+      }
+    }
+  };
+
+  return {
+    convertToImage: convertToImage,
+    convertToJPEG: function (
+      canvas: HTMLCanvasElement,
+      width: number,
+      height: number
+    ) {
+      return convertToImage(canvas, width, height, "jpeg");
+    },
+  };
+};
+
+export const generateAppScreenshot = async () => {
+  try {
+    const el = document.querySelector(".stApp") as HTMLDivElement;
+    console.log(el);
+    const canvas = await html2canvas(el, {
+      allowTaint: true,
+      x: 0,
+      y: 0,
+      scrollX: 0,
+      scrollY: 0,
+    });
+
+    console.log("el", el, "canvas", canvas);
+
+    const base64Img = Canvas2Image()!.convertToJPEG(canvas, 258, 150)!.src;
+    console.log("img", base64Img);
+    return base64Img;
+  } catch (err) {
+    console.error(err);
+  }
+};

--- a/packages/mountable/package.json
+++ b/packages/mountable/package.json
@@ -173,5 +173,8 @@
     "presets": [
       "react-app"
     ]
+  },
+  "dependencies": {
+    "html2canvas": "^1.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5390,13 +5390,22 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17", "@types/react@^17.0.7", "@types/react@^18.2.0":
+"@types/react@*", "@types/react@^18.2.0":
   version "18.2.65"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.65.tgz#54eb311fa9aba173c9e163d42ec188d5a42878b8"
   integrity sha512-98TsY0aW4jqx/3RqsUXwMDZSWR1Z4CUlJNue8ueS2/wcxZOsz4xmW1X8ieaWVRHcmmQM3R8xVA4XWB3dJnWwDQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17", "@types/react@^17.0.7":
+  version "17.0.80"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.80.tgz#a5dfc351d6a41257eb592d73d3a85d3b7dbcbb41"
+  integrity sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/reactcss@*":
@@ -5425,7 +5434,7 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
-"@types/scheduler@*":
+"@types/scheduler@*", "@types/scheduler@^0.16":
   version "0.16.8"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
   integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
@@ -8379,6 +8388,13 @@ css-in-js-utils@^2.0.0:
   dependencies:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
+
+css-line-break@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-2.1.0.tgz#bfef660dfa6f5397ea54116bb3cb4873edbc4fa0"
+  integrity sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==
+  dependencies:
+    utrie "^1.0.2"
 
 css-loader@^6.5.1:
   version "6.8.1"
@@ -12623,6 +12639,14 @@ html-webpack-plugin@^5.5.0:
     pretty-error "^4.0.0"
     tapable "^2.0.0"
 
+html2canvas@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
+  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
+
 htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
@@ -12883,7 +12907,7 @@ immer@^9.0.19, immer@^9.0.7:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
-immutable@4.2.3, immutable@^4.0.0:
+immutable@^4.0.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.2.3.tgz#a203cdda37a5a30bc351b982a1794c1930198815"
   integrity sha512-IHpmvaOIX4VLJwPOuQr1NpeBr2ZG6vpIj3blsLVxXRWJscLioaJRStqC+NcBsLeCDsnGlPpXd5/WZmnE7MbsKA==
@@ -21349,6 +21373,13 @@ text-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-2.4.0.tgz#a1cfcc50cf34da41bfd047cc744f804d1680ea34"
   integrity sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==
 
+text-segmentation@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/text-segmentation/-/text-segmentation-1.0.3.tgz#52a388159efffe746b24a63ba311b6ac9f2d7943"
+  integrity sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==
+  dependencies:
+    utrie "^1.0.2"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -22225,6 +22256,13 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+utrie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.2.tgz#d42fe44de9bc0119c25de7f564a6ed1b2c87a645"
+  integrity sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==
+  dependencies:
+    base64-arraybuffer "^1.0.2"
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
I moved the code for generating screenshot in this repo because of we are not able to generate screenshot for content from different origin other then where the app runs. This means that we can not generate the screenshot and capture the app from fusion stlite app.

I added new package `html2canvas` that generates the canvas and copy-pasted a code from google (copilot) that scales and converts the canvas into an image with the dimensions we want. Finally we are sending the image as base64 encoded string to parent app.

Closes
https://github.com/cognitedata/cog-ai/issues/1871