### PR TITLE
improve: make nicer screenshots and ensure <8Kb

### DIFF
--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -53,6 +53,8 @@ export const generateAppScreenshot = async () => {
   const WIDTH = 308;
   const HEIGHT = 176;
   const MAX_SCREENSHOT_SIZE = 8 * 1024; // Generate screenshot that is max 8Kb
+  const IMAGE_TYPE = "image/webp";
+
   const el = document.querySelector(".block-container div") as HTMLDivElement;
   const elPadding = el.style.padding;
   el.style.paddingLeft = "32px";
@@ -63,7 +65,7 @@ export const generateAppScreenshot = async () => {
       el,
       WIDTH,
       HEIGHT,
-      "image/webp",
+      IMAGE_TYPE,
       quality
     );
     while (quality > 0.1 && result.length > MAX_SCREENSHOT_SIZE) {
@@ -71,13 +73,7 @@ export const generateAppScreenshot = async () => {
       console.warn(
         `Generated screenshot was ${result.length} bytes (>${MAX_SCREENSHOT_SIZE} bytes), reducing quality to ${quality} and trying again...`
       );
-      result = await generateScreenshot(
-        el,
-        WIDTH,
-        HEIGHT,
-        "image/webp",
-        quality
-      );
+      result = await generateScreenshot(el, WIDTH, HEIGHT, IMAGE_TYPE, quality);
     }
     return result;
   } finally {

--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -63,7 +63,7 @@ export const generateAppScreenshot = async () => {
       el,
       WIDTH,
       HEIGHT,
-      "image/jpeg",
+      "image/webp",
       quality
     );
     while (quality > 0.1 && result.length > MAX_SCREENSHOT_SIZE) {
@@ -75,7 +75,7 @@ export const generateAppScreenshot = async () => {
         el,
         WIDTH,
         HEIGHT,
-        "image/jpeg",
+        "image/webp",
         quality
       );
     }


### PR DESCRIPTION
Fixes https://github.com/cognitedata/cog-ai/issues/2150

Did a few changes to improve screenshots:

1. Switch from JPEG to WEBP for improved compression
2. Maintain aspect ratio when resizing
3. Change padding to avoid too much white space on top of screenshot
4. When generated image is above 8Kb, reduce quality until its not
1. Reduce amount of ridicolous code in generate-screenshot.ts - ChatGPT doesn't always produce nice code...

| Before | After |
| ------ | ----- |
| ![image](https://github.com/cognitedata/stlite/assets/6741854/3007c0b4-c875-494b-991d-6202069d27eb) |  ![image](https://github.com/cognitedata/stlite/assets/6741854/d338c48e-2daa-4ccc-a536-676186bb7fab) |
| ![image](https://github.com/cognitedata/stlite/assets/6741854/836d805a-c748-4765-9a14-54d402dca1c5) | ![image](https://github.com/cognitedata/stlite/assets/6741854/9e8450e5-8756-4bed-b32f-4c6d0036daa1) |
| ![image](https://github.com/cognitedata/stlite/assets/6741854/4db82562-c586-4301-945c-6343cf5499e5) | ![image](https://github.com/cognitedata/stlite/assets/6741854/37e6f70d-7b68-4ba0-9a1a-8d007293362c) |
| ![image](https://github.com/cognitedata/stlite/assets/6741854/60a9003f-fee4-4795-9b4e-f2d892b153a8) | ![image](https://github.com/cognitedata/stlite/assets/6741854/7ac24017-6672-42c0-910b-96b7b3dbed65) |






