### PR TITLE
fix: capped screenshots

### DIFF
--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -67,5 +67,5 @@ export const generateAppScreenshot = async () => {
     );
     result = await generateScreenshot(el, WIDTH, HEIGHT, IMAGE_TYPE, quality);
   }
+  return result;
 };
-return result;

--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -15,7 +15,6 @@ async function generateScreenshot(
     scrollX: 0,
     scrollY: 0,
   })) as HTMLCanvasElement;
-  // return originalCanvas.toDataURL(type, quality / 10.0);
 
   // Code below for resizing image is by ChatGPT (https://chat.openai.com/share/0f6edbe5-3152-4040-9122-d78f8855ae8b)
 
@@ -38,7 +37,6 @@ async function generateScreenshot(
   // Draw the resized image onto the new canvas
   ctx.fillStyle = "white";
   ctx.fillRect(0, 0, newCanvas.width, newCanvas.height);
-
   ctx.drawImage(
     originalCanvas,
     offsetX,

--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -5,7 +5,8 @@ async function generateScreenshot(
   width: number,
   height: number,
   type: string,
-  quality = 0.8
+  quality = 0.8,
+  paddingWidthFactor = 1.1
 ) {
   const originalCanvas = (await html2canvas(htmlElement, {
     allowTaint: true,
@@ -14,6 +15,7 @@ async function generateScreenshot(
     scrollX: 0,
     scrollY: 0,
   })) as HTMLCanvasElement;
+  // return originalCanvas.toDataURL(type, quality / 10.0);
 
   // Code below for resizing image is by ChatGPT (https://chat.openai.com/share/0f6edbe5-3152-4040-9122-d78f8855ae8b)
 
@@ -27,16 +29,16 @@ async function generateScreenshot(
   newCanvas.height = height;
 
   // Calculate the scaling factor
-  const scale = Math.max(
-    width / originalCanvas.width,
-    height / originalCanvas.height
-  );
+  const scale = width / (paddingWidthFactor * originalCanvas.width);
 
   // Calculate the position to draw the original canvas on the new canvas
   const offsetX = (width - originalCanvas.width * scale) / 2;
   const offsetY = 0; // Since we are "zooming" to the top middle, the Y-offset is 0
 
   // Draw the resized image onto the new canvas
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, newCanvas.width, newCanvas.height);
+
   ctx.drawImage(
     originalCanvas,
     offsetX,
@@ -57,8 +59,8 @@ export const generateAppScreenshot = async () => {
 
   const el = document.querySelector(".block-container div") as HTMLDivElement;
   const elPadding = el.style.padding;
-  el.style.paddingLeft = "32px";
-  el.style.paddingRight = "32px";
+  el.style.paddingLeft = "0px";
+  el.style.paddingRight = "0px";
   try {
     let quality = 0.7;
     let result = await generateScreenshot(

--- a/packages/kernel/src/cognite/generate-screenshot.ts
+++ b/packages/kernel/src/cognite/generate-screenshot.ts
@@ -58,28 +58,14 @@ export const generateAppScreenshot = async () => {
   const IMAGE_TYPE = "image/webp";
 
   const el = document.querySelector(".block-container div") as HTMLDivElement;
-  const elPadding = el.style.padding;
-  el.style.paddingLeft = "0px";
-  el.style.paddingRight = "0px";
-  try {
-    let quality = 0.7;
-    let result = await generateScreenshot(
-      el,
-      WIDTH,
-      HEIGHT,
-      IMAGE_TYPE,
-      quality
+  let quality = 0.7;
+  let result = await generateScreenshot(el, WIDTH, HEIGHT, IMAGE_TYPE, quality);
+  while (quality > 0.1 && result.length > MAX_SCREENSHOT_SIZE) {
+    quality -= 0.1;
+    console.warn(
+      `Generated screenshot was ${result.length} bytes (>${MAX_SCREENSHOT_SIZE} bytes), reducing quality to ${quality} and trying again...`
     );
-    while (quality > 0.1 && result.length > MAX_SCREENSHOT_SIZE) {
-      quality -= 0.1;
-      console.warn(
-        `Generated screenshot was ${result.length} bytes (>${MAX_SCREENSHOT_SIZE} bytes), reducing quality to ${quality} and trying again...`
-      );
-      result = await generateScreenshot(el, WIDTH, HEIGHT, IMAGE_TYPE, quality);
-    }
-    return result;
-  } finally {
-    // Restore previous padding
-    el.style.padding = elPadding;
+    result = await generateScreenshot(el, WIDTH, HEIGHT, IMAGE_TYPE, quality);
   }
 };
+return result;


### PR DESCRIPTION
Fixes a bug caused by #41 causing screenshots to be capped at the right boundary.