### PR TITLE
fix: mock pyarrow (regression from #37)

### DIFF
--- a/packages/kernel/src/worker-runtime.ts
+++ b/packages/kernel/src/worker-runtime.ts
@@ -242,7 +242,7 @@ with tarfile.open("${mountedSitePackagesSnapshotFilePath}", "r") as tar_gz_file:
 
       postProgressMessage("Mocking some packages.");
       console.debug("Mock pyarrow");
-      //mockPyArrow(pyodide);
+      mockPyArrow(pyodide);
       console.debug("Mocked pyarrow");
     } else {
       console.debug("Installing the requirements:", requirements);


### PR DESCRIPTION
Uncomment errornously commented code for mocking pyarrow after update to stlite v0.54.

Fixes https://github.com/cognitedata/cog-ai/issues/2139