### PR TITLE
fix: lock requests package to 2.31.0 due to problem with 2.32.x

### DIFF
--- a/packages/kernel/py/stlite-server/pyproject.toml
+++ b/packages/kernel/py/stlite-server/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.10, <3.12"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
-requests = "^2.31.0"
+requests = "2.31.0"
 black = "^24.2.0"
 flake8 = "^7.0.0"
 isort = "^5.13.2"


### PR DESCRIPTION
Workaround for https://github.com/cognitedata/cog-ai/issues/2163