### PR TITLE
fix: app window is all white after printing

### DIFF
--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -448,7 +448,10 @@ const initTokenStorageAndAuthHandler = (worker: StliteWorker) => {
             data: appScreenshot,
           });
         } else if (event.data.type === "streamlit-app-print") {
-          window.print();
+          // Workaround for https://issues.chromium.org/issues/40094746
+          setTimeout(() => {
+            window.print();
+          }, 0);
         } else if (event.data.type.startsWith("language-server:")) {
           // StreamLit app main thread, forward the message to the worker
           // so that the kernel can process the request


### PR DESCRIPTION
Fixes bug causing app to be blank after printing in Chrome. Caused by https://issues.chromium.org/issues/40094746