### PR TITLE
fix: update deprecated GitHub Actions artifact versions from v3 to v4

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -105,7 +105,7 @@ jobs:
         run: cp firebase.json packages/mountable/build/
       - if: matrix.target == 'mountable'
         name: Upload the built files as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: stlite-mountable
           path: packages/mountable/build
@@ -123,7 +123,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: stlite-mountable
           path: mountable

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -105,7 +105,7 @@ jobs:
         run: cp firebase.json packages/mountable/build/
       - if: matrix.target == 'mountable'
         name: Upload the built files as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: stlite-mountable
           path: packages/mountable/build
@@ -123,7 +123,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: stlite-mountable
           path: mountable


### PR DESCRIPTION
GitHub Actions workflows were failing with the following error:
```
Error: This request has been automatically failed because it uses a deprecated version of \`actions/upload-artifact: v3\`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

## Solution

Updated all deprecated GitHub Actions artifact versions from v3 to v4:

- `actions/upload-artifact@v3` → `actions/upload-artifact@v4`
- `actions/download-artifact@v3` → `actions/download-artifact@v4`

## Files Changed

- `.github/workflows/deploy-staging.yml`
- `.github/workflows/deploy-production.yml`

## References

- [GitHub Blog: Deprecation notice for v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
- [actions/upload-artifact v4 documentation](https://github.com/actions/upload-artifact)
- [actions/download-artifact v4 documentation](https://github.com/actions/download-artifact)

## Testing

The workflows should now run without deprecation warnings and use the latest supported versions of the artifact actions.