### PR TITLE
fix: changed public url to be absolute to load js files better

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -89,10 +89,10 @@ jobs:
         run: make init
 
       ## Build and deploy @stlite/mountable
-      # PUBLIC_URL here is set as a relative path, which is possible to the trick introduced at https://github.com/whitphx/stlite/pull/143.
+      # PUBLIC_URL here is set as an absolute path to fix asset loading issues with nested routes (e.g. Dune apps)
       - if: matrix.target == 'mountable'
         name: Set PUBLIC_URL
-        run: echo "PUBLIC_URL=." >> $GITHUB_ENV
+        run: echo "PUBLIC_URL=/" >> $GITHUB_ENV
 
       - if: matrix.target == 'mountable'
         name: Build @stlite/mountable


### PR DESCRIPTION
### Problem
Our deployment was failing to load `stlite.js` when accessed via nested routes like:
- `https://cognite-stlite-standalone-staging.web.app/development/5000`

The browser was trying to load assets from:
- ❌ `https://cognite-stlite-standalone-staging.web.app/development/stlite.js` (relative path)
- Instead of: ✅ `https://cognite-stlite-standalone-staging.web.app/stlite.js` (absolute path)

### Root Cause
The webpack build was configured with `PUBLIC_URL=.` (relative path), which causes asset URLs to resolve relative to the current URL path. This breaks nested routes like those used by Dune apps.

### Solution
Changed the staging workflow to use `PUBLIC_URL=/` (absolute path) instead of `PUBLIC_URL=.` (relative path).

### Testing
- ✅ `https://cognite-stlite-standalone-staging.web.app` (root path - already working)
- ✅ `https://cognite-stlite-standalone-staging.web.app/someAppId` (single level - already working)  
- ✅ `https://cognite-stlite-standalone-staging.web.app/development/5000` (nested path - will be fixed)

We can test this in staging before deploying to prod to ensure it works out there.