### PR TITLE
fix: add polyfills for TransformStreams, TextEncoder and TextDecoder to enable use of @zip.js/zip.js in tests

### DIFF
--- a/packages/mountable/package.json
+++ b/packages/mountable/package.json
@@ -53,6 +53,7 @@
     "css-minimizer-webpack-plugin": "^3.2.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
+    "fast-text-encoding": "^1.0.6",
     "file-loader": "^6.2.0",
     "fs-extra": "^11.2.0",
     "html-webpack-plugin": "^5.5.0",
@@ -81,6 +82,7 @@
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.0.2",
     "terser-webpack-plugin": "^5.2.5",
+    "web-streams-polyfill": "^4.2.0",
     "web-vitals": "^3.5.2",
     "webpack": "5.76.0",
     "webpack-dev-server": "^4.6.0",
@@ -123,7 +125,9 @@
       "!src/**/*.d.ts"
     ],
     "setupFiles": [
-      "react-app-polyfill/jsdom"
+      "react-app-polyfill/jsdom",
+      "web-streams-polyfill/dist/polyfill",
+      "fast-text-encoding"
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/src/setupTests.ts"

--- a/packages/mountable/src/dune/utils/fileUtils.ts
+++ b/packages/mountable/src/dune/utils/fileUtils.ts
@@ -2,6 +2,8 @@
 // is used by cognite-sdk. This ended up being quite a bit of work to fix, so we just
 // download the files directly using fetch instead.
 
+import { ZipReader, Uint8ArrayReader, Uint8ArrayWriter } from "@zip.js/zip.js";
+
 export interface SourceCodeResult {
   [filePath: string]: string;
 }
@@ -143,10 +145,6 @@ export const isZipFile = (fileName: string, mimeType?: string): boolean => {
 export const defaultGetZipEntries = async (
   binaryData: ArrayBuffer,
 ): Promise<ZipEntry[]> => {
-  const { ZipReader, Uint8ArrayReader, Uint8ArrayWriter } = await import(
-    "@zip.js/zip.js"
-  );
-
   const zipReader = new ZipReader(
     new Uint8ArrayReader(new Uint8Array(binaryData)),
   );

--- a/packages/mountable/src/setupTests.ts
+++ b/packages/mountable/src/setupTests.ts
@@ -1,7 +1,7 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
+// // jest-dom adds custom jest matchers for asserting on DOM nodes.
+// // allows you to do things like:
+// // expect(element).toHaveTextContent(/react/i)
+// // learn more: https://github.com/testing-library/jest-dom
 // import '@testing-library/jest-dom';
 
 

--- a/packages/mountable/src/setupTests.ts
+++ b/packages/mountable/src/setupTests.ts
@@ -1,13 +1,7 @@
-// // jest-dom adds custom jest matchers for asserting on DOM nodes.
-// // allows you to do things like:
-// // expect(element).toHaveTextContent(/react/i)
-// // learn more: https://github.com/testing-library/jest-dom
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
 // import '@testing-library/jest-dom';
 
-// Polyfill for TextEncoder/TextDecoder in Node.js test environment
-import { TextEncoder, TextDecoder } from "util";
 
-// We do as any because the Node.js TextEncoder/TextDecoder are not the same as the browser TextEncoder/TextDecoder
-// but we dont see that difference in our tests.
-global.TextEncoder = TextEncoder as any;
-global.TextDecoder = TextDecoder as any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11242,6 +11242,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-text-encoding@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
+  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
+
 fast-xml-parser@^4.2.5:
   version "4.4.1"
   resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz"
@@ -22473,7 +22478,7 @@ util.promisify@~1.0.0:
 
 util@^0.12.5:
   version "0.12.5"
-  resolved "https://registry.npmjs.org/util/-/util-0.12.5.tgz"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
   integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
   dependencies:
     inherits "^2.0.3"
@@ -23139,6 +23144,11 @@ web-streams-polyfill@^3.0.3:
   version "3.3.2"
   resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz"
   integrity sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==
+
+web-streams-polyfill@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.2.0.tgz#93295e67af95889a1e044a6beff1366c82720650"
+  integrity sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==
 
 web-vitals@^3.5.2:
   version "3.5.2"


### PR DESCRIPTION
The polyfills are only installed as devDependencies so only affects the tests and not the production bundle.